### PR TITLE
add (undocumented ;-) ssh call

### DIFF
--- a/api.go
+++ b/api.go
@@ -13,9 +13,11 @@ import (
 var (
 	cloudkey = flag.String("cloudkey", "", "Path to cloudkey ( or CLOUDKEY environment )")
 	cloudurl = flag.String("cloudurl", "", "Cloud URL ( or CLOUDURL environment )")
+	sshkey   = flag.String("sshkey", "~/.ssh/id_ed25519", "SSH keypath for ssh")
 )
 
 var cloudUrl string
+var sshKey string
 
 func createJail(disksize string, key string, name string) {
 

--- a/api.go
+++ b/api.go
@@ -13,7 +13,7 @@ import (
 var (
 	cloudkey = flag.String("cloudkey", "", "Path to cloudkey ( or CLOUDKEY environment )")
 	cloudurl = flag.String("cloudurl", "", "Cloud URL ( or CLOUDURL environment )")
-	sshkey   = flag.String("sshkey", "~/.ssh/id_ed25519", "SSH keypath for ssh")
+	sshkey   = flag.String("sshkey", "~/.ssh/id_ed25519", "SSH keypath for ssh ( or SSHKEY environment )")
 )
 
 var cloudUrl string

--- a/main.go
+++ b/main.go
@@ -93,6 +93,14 @@ func main() {
 		cloudUrl = os.Getenv("CLOUDURL")
 	}
 
+	// sshKey: get from args
+	if len(*sshkey) > 1 {
+		sshKey = *sshkey
+	} else {
+		// sshKey: get from env(1)
+		sshKey = os.Getenv("SSHKEY")
+	}
+
 	if len(cloudUrl) < 2 {
 		fmt.Printf("no such CLOUDURL env or --cloudurl\n")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -130,6 +130,16 @@ func main() {
 		applyConfig(pubkey)
 	} else if command == "divert" {
 		divertConfig(apitoken)
+	} else if command == "ssh" {
+		if len(cloudUrl) < 2 {
+			fmt.Printf("no such SSHKEY env or --sshkey\n")
+			os.Exit(1)
+		}
+		if len(os.Args) == 3 {
+			sshResource(os.Args[2], apitoken)
+		} else {
+			sshSelectResource(apitoken)
+		}
 	}
 
 	//fmt.Println(pubkey)

--- a/ssh.go
+++ b/ssh.go
@@ -1,0 +1,115 @@
+// Mock ssh file until golang-based ssh terminal work is stabilized.
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"encoding/json"
+	"net/http"
+	"io"
+	"strings"
+	"syscall"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+)
+
+// Golang has no built-in realpath(1) (e.g. for tilde expansion)
+func expand(path string) (string, error) {
+	if len(path) == 0 || path[0] != '~' {
+		return path, nil
+	}
+
+	usr, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(usr.HomeDir, path[1:]), nil
+}
+
+// pass SSH args to external ssh binary
+func doSSH(sshKeyPath string, username string, hostname string, port int) {
+	sshString := fmt.Sprintf("ssh -i %s %s@%s -p%d", sshKeyPath, username, hostname, port)
+	fmt.Fprintln(os.Stderr,"[debug] using sshkey: ", sshKey)
+	fmt.Fprintln(os.Stderr,"[debug] ssh str:", sshString)
+
+	sshArgs := strings.Fields(sshString)
+
+	//syscall.Exec req for full/realpath to binaries
+	binary, lookErr := exec.LookPath("ssh")
+	if lookErr != nil {
+		panic(lookErr)
+	}
+
+	syscall.Exec(binary, sshArgs, os.Environ())
+}
+
+
+func sshResource(name string, keyID string) {
+
+	var statusurl string
+
+	sshKeyPath, _ := expand(*sshkey)
+
+	if !fileExists(sshKeyPath) {
+		fmt.Printf("no such SSHKEY env or --sshkey: %s\n", sshKeyPath)
+		os.Exit(1)
+	}
+
+	//get status for 'name' environment
+	statusurl = cloudUrl + "/api/v1/status/" + name
+
+	request, error := http.NewRequest("GET", statusurl, nil)
+	request.Header.Set("cid", keyID)
+	client := &http.Client{}
+	response, error := client.Do(request)
+	if error != nil {
+		panic(error)
+	}
+	defer response.Body.Close()
+
+	body, _ := ioutil.ReadAll(response.Body)
+	decoder := json.NewDecoder(strings.NewReader(string(body)))
+
+	for {
+		var m interface{}
+		if err := decoder.Decode(&m); err == io.EOF {
+			break
+		} else if err != nil {
+			fmt.Fprintln(os.Stderr,"fatal:")
+			//log.Fatal(err)
+		}
+//		fmt.Fprintln(os.Stderr,"res:", m)
+
+//		md, ok := m.(map[string]interface{})
+		md, _ := m.(map[string]interface{})
+
+		value, exists := md["instanceid"]
+		// In case when key is not present in map variable exists will be false.
+		if exists {
+			//fmt.Printf("key exists in map: %t, value: %v \n", exists, value)
+			if value == name {
+				fmt.Printf("key exists in map: %t, value: %v \n", exists, value)
+				ssh_user, _ := md["ssh_user"]
+				ssh_host, _ := md["ssh_host"]
+				ssh_port, _ := md["ssh_port"]
+
+				//  need type assertion from interface
+				username, _ := ssh_user.(string)
+				hostname, _ := ssh_host.(string)
+				ssh_port_int, _ := ssh_port.(float64)
+				var port int = int(ssh_port_int)
+
+				fmt.Printf("%s@%s -p %d\n", ssh_user,ssh_host, port)
+				doSSH(sshKeyPath, username, hostname, port)
+			}
+		}
+	}
+}
+
+// interactive build/select list via promptui.Select
+// from getStatus -> instanceid name
+func sshSelectResource(keyID string) {
+	//wip
+}


### PR DESCRIPTION
usage:
  nubectl ssh <env>

SSHKEY or --sshkey must point to the private key ( ~/.ssh/id_ed25519 by default)

todo: dynamic selection of env via promptui.Select
todo: rewrite external ssh call to golang ssh